### PR TITLE
chore: Bump alpine base image from 3.13 to latest 3.19.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.13
+FROM alpine:3.19.1
 
 RUN apk add --no-cache ca-certificates \
  && adduser -D -u 1000 jx


### PR DESCRIPTION
The latest version of alpine is currenty 3.19.1
https://www.alpinelinux.org/downloads/
