### PR TITLE
feat: add Gateway API support

### DIFF
--- a/charts/lighthouse-webui-plugin/templates/gatewayapi.yaml
+++ b/charts/lighthouse-webui-plugin/templates/gatewayapi.yaml
@@ -1,0 +1,78 @@
+{{- if .Values.gatewayApi.enabled -}}
+
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "webui.fullname" . }}
+  labels:
+    {{- include "webui.labels" . | nindent 4 }}
+    {{- with .Values.gatewayApi.labels }}
+      {{- tpl (toYaml .) $ | trim | nindent 4 }}
+    {{- end }}
+  {{- with .Values.gatewayApi.annotations }}
+  annotations:
+    {{- tpl (toYaml .) $ | trim | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: {{ .Values.gatewayApi.parentRef.name }}
+    {{- with .Values.gatewayApi.parentRef.namespace }}
+    namespace: {{ . }}
+    {{- end }}
+    {{- with .Values.gatewayApi.parentRef.sectionName }}
+    sectionName: {{ . }}
+    {{- end }}
+  {{- if .Values.gatewayApi.hosts }}
+  hostnames:
+  {{- range .Values.gatewayApi.hosts }}
+  - {{ tpl . $ | quote }}
+  {{- end }}
+  {{- end }}
+  rules:
+  {{- if .Values.gatewayApi.rules }}
+  {{- range $rule := .Values.gatewayApi.rules }}
+  {{- if not $rule.backendRefs }}
+  {{- $_ := set $rule "backendRefs" (list (dict "group" "" "kind" "Service" "name" (include "webui.fullname" $) "port" (int $.Values.service.port))) }}
+  {{- end }}
+  {{- tpl (toYaml (list $rule)) $ | nindent 2 }}
+  {{- end }}
+  {{- else }}
+  - backendRefs:
+    - group: ""
+      kind: Service
+      name: {{ include "webui.fullname" . }}
+      port: {{ .Values.service.port | int }}
+  {{- end }}
+
+{{- if and .Values.gatewayApi.basicAuth.enabled (eq (.Values.gatewayApi.basicAuth.kind | default "envoy") "envoy") }}
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: {{ include "webui.fullname" . }}-basic-auth
+  labels:
+    {{- include "webui.labels" . | nindent 4 }}
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: {{ include "webui.fullname" . }}
+  basicAuth:
+    users:
+      name: {{ include "webui.fullname" . }}-basic-auth
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "webui.fullname" . }}-basic-auth
+  labels:
+    {{- include "webui.labels" . | nindent 4 }}
+type: Opaque
+data:
+  .htpasswd: {{ .Values.gatewayApi.basicAuth.authData | quote }}
+{{- end }}
+
+{{- end -}}

--- a/charts/lighthouse-webui-plugin/values.yaml
+++ b/charts/lighthouse-webui-plugin/values.yaml
@@ -109,6 +109,23 @@ istio:
   apiVersion: networking.istio.io/v1beta1
   gateway: jx-gateway
 
+
+gatewayApi:
+  enabled: false
+  kind: HTTPRoute
+  labels: {}
+  annotations: {}
+  parentRef:
+    name: envoy-gateway
+    namespace:
+    sectionName:
+  hosts: []
+  rules: []
+  basicAuth:
+    enabled: false
+    kind: envoy
+    authData: ""
+
 # persistence for the events
 persistence:
   enabled: false


### PR DESCRIPTION
### Changes

* Create `charts/lighthouse-webui-plugin/templates/gatewayapi.yaml` template
* Add Add `gatewayApi` block with sensible defaults to `charts/lighthouse-webui-plugin/values.yaml`

### Context

This PR adds Gateway API support via the `gatewayApi` block. This is an alternative to the existing Ingress resource for exposing the UI.

There is no one-to-one feature parity with Ingress, so the chart must make some further assumptions about the end-user's cluster setup:
* A pre-existing Gateway implementation must be installed in the cluster. The user's Gateway owns TLS termination, so is not included here
* JayeX versionStream natively supports Envoy Gateway, so the default are geared to use this:
  * `parentRef` points to `envoy-gateway` & `envoy-gateway-system`
  * Basic Auth implemented with an Envoy Gateway `SecurityPolicy` (`gatewayApi.basicAuth.kind: envoy`)
                                                                                                                                                                                                                                                                                                                                                           
`gatewayApi.enabled` and `ingress.enabled` are independent, so both can be set during a migration. Everything defaults to `enabled: false`, so this is a no-op for existing installs.

Part of https://github.com/jenkins-x/jx/issues/8962
