### PR TITLE
chore: enable use of existingSecret for basic auth

### DIFF
--- a/charts/lighthouse-webui-plugin/templates/gatewayapi.yaml
+++ b/charts/lighthouse-webui-plugin/templates/gatewayapi.yaml
@@ -62,7 +62,8 @@ spec:
     name: {{ include "webui.fullname" . }}
   basicAuth:
     users:
-      name: {{ include "webui.fullname" . }}-basic-auth
+      name: {{ .Values.gatewayApi.basicAuth.existingSecret | default (printf "%s-basic-auth" (include "webui.fullname" .)) }}
+{{- if not .Values.gatewayApi.basicAuth.existingSecret }}
 ---
 apiVersion: v1
 kind: Secret
@@ -73,6 +74,7 @@ metadata:
 type: Opaque
 data:
   .htpasswd: {{ .Values.gatewayApi.basicAuth.authData | quote }}
+{{- end }}
 {{- end }}
 
 {{- end -}}

--- a/charts/lighthouse-webui-plugin/values.yaml
+++ b/charts/lighthouse-webui-plugin/values.yaml
@@ -125,6 +125,9 @@ gatewayApi:
     enabled: false
     kind: envoy
     authData: ""
+    # when set, reference this existing secret (must contain a ".htpasswd" key)
+    # instead of creating one from authData
+    existingSecret: ""
 
 # persistence for the events
 persistence:

--- a/charts/lighthouse-webui-plugin/values.yaml
+++ b/charts/lighthouse-webui-plugin/values.yaml
@@ -125,8 +125,7 @@ gatewayApi:
     enabled: false
     kind: envoy
     authData: ""
-    # when set, reference this existing secret (must contain a ".htpasswd" key)
-    # instead of creating one from authData
+    # existing secret must contain a ".htpasswd" key
     existingSecret: ""
 
 # persistence for the events


### PR DESCRIPTION
### Changes:

* Add `gatewayApi.basicAuth.existingSecret` for basic auth in chart

### Context

Allows use of `jx-basic-auth-htpasswd` from jxboot's secret-schema in https://github.com/jenkins-x/jx3-versions